### PR TITLE
Update to 1.20.2 + Nether Fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.21
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.1
+loader_version=0.14.22
 # Mod Properties
 mod_version=1.6.2
 maven_group=us.potatoboy

--- a/src/main/java/us/potatoboy/worldborderfix/mixin/MinecraftServerMixin.java
+++ b/src/main/java/us/potatoboy/worldborderfix/mixin/MinecraftServerMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.WorldGenerationProgressListener;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.world.PersistentState;
 import net.minecraft.world.World;
 import net.minecraft.world.border.WorldBorder;
 import net.minecraft.world.border.WorldBorderListener;
@@ -33,7 +34,8 @@ public abstract class MinecraftServerMixin {
 			WorldBorder worldBorder = world.getWorldBorder();
 
 			if (registryKey.getValue() != DimensionOptions.OVERWORLD.getValue()) {
-				WorldBorderState worldBorderState = world.getPersistentStateManager().getOrCreate(WorldBorderState::fromNbt, WorldBorderState::new, "worldBorder");
+				// Requires fabric-object-builder-api-v1 (see https://github.com/FabricMC/fabric/issues/3327 for more information, why we are passing null as the dataFixTypes)
+				WorldBorderState worldBorderState = world.getPersistentStateManager().getOrCreate(new PersistentState.Type<>(WorldBorderState::new, WorldBorderState::fromNbt, null), "worldBorder");
 
 				worldBorder.setCenter(worldBorderState.getCenterX(), worldBorderState.getCenterZ());
 				worldBorder.setSize(worldBorderState.getSize());

--- a/src/main/java/us/potatoboy/worldborderfix/mixin/ServerWorldMixin.java
+++ b/src/main/java/us/potatoboy/worldborderfix/mixin/ServerWorldMixin.java
@@ -1,6 +1,7 @@
 package us.potatoboy.worldborderfix.mixin;
 
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.PersistentState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,7 +13,8 @@ public abstract class ServerWorldMixin {
     @Inject(method = "saveLevel", at = @At("HEAD"))
     private void saveBorder(CallbackInfo ci) {
         ServerWorld world = (ServerWorld) (Object) this;
-        WorldBorderState worldBorderState = world.getPersistentStateManager().getOrCreate(WorldBorderState::fromNbt, WorldBorderState::new, "worldBorder");
+        // Requires fabric-object-builder-api-v1 (see https://github.com/FabricMC/fabric/issues/3327 for more information, why we are passing null as the dataFixTypes)
+        WorldBorderState worldBorderState = world.getPersistentStateManager().getOrCreate(new PersistentState.Type<>(WorldBorderState::new, WorldBorderState::fromNbt, null), "worldBorder");
 
         worldBorderState.fromBorder(world.getWorldBorder());
     }

--- a/src/main/java/us/potatoboy/worldborderfix/mixin/WorldBorderCenterChangePacketMixin.java
+++ b/src/main/java/us/potatoboy/worldborderfix/mixin/WorldBorderCenterChangePacketMixin.java
@@ -17,11 +17,10 @@ public abstract class WorldBorderCenterChangePacketMixin {
     private double scaleCenterX(WorldBorder worldBorder) {
         World world = ((BorderWithWorld) worldBorder).getWorld();
 
-        if (world != null) {
-            return worldBorder.getCenterX();
-        }
-
-        return worldBorder.getCenterX();
+        // The client is going to divide our world border center by the coordinate scale, so we need to multiply it by
+        // the coordinate scale to compensate for this.
+        final double centerX = worldBorder.getCenterX();
+        return world == null || world.isClient ? centerX : centerX * world.getDimension().coordinateScale();
     }
 
     @Redirect(
@@ -31,10 +30,9 @@ public abstract class WorldBorderCenterChangePacketMixin {
     private double scaleCenterZ(WorldBorder worldBorder) {
         World world = ((BorderWithWorld) worldBorder).getWorld();
 
-        if (world != null) {
-            return worldBorder.getCenterZ();
-        }
-
-        return worldBorder.getCenterZ();
+        // The client is going to divide our world border center by the coordinate scale, so we need to multiply it by
+        // the coordinate scale to compensate for this.
+        final double centerZ = worldBorder.getCenterZ();
+        return world == null || world.isClient ? centerZ : centerZ * world.getDimension().coordinateScale();
     }
 }

--- a/src/main/java/us/potatoboy/worldborderfix/mixin/WorldBorderInitializeS2CPacketMixin.java
+++ b/src/main/java/us/potatoboy/worldborderfix/mixin/WorldBorderInitializeS2CPacketMixin.java
@@ -17,11 +17,10 @@ public abstract class WorldBorderInitializeS2CPacketMixin {
     private double scaleCenterX(WorldBorder worldBorder) {
         World world = ((BorderWithWorld) worldBorder).getWorld();
 
-        if (world != null) {
-            return worldBorder.getCenterX();
-        }
-
-        return worldBorder.getCenterX();
+        // The client is going to divide our world border center by the coordinate scale, so we need to multiply it by
+        // the coordinate scale to compensate for this.
+        final double centerX = worldBorder.getCenterX();
+        return world == null || world.isClient ? centerX : centerX * world.getDimension().coordinateScale();
     }
 
     @Redirect(
@@ -31,10 +30,9 @@ public abstract class WorldBorderInitializeS2CPacketMixin {
     private double scaleCenterZ(WorldBorder worldBorder) {
         World world = ((BorderWithWorld) worldBorder).getWorld();
 
-        if (world != null) {
-            return worldBorder.getCenterZ();
-        }
-
-        return worldBorder.getCenterZ();
+        // The client is going to divide our world border center by the coordinate scale, so we need to multiply it by
+        // the coordinate scale to compensate for this.
+        final double centerZ = worldBorder.getCenterZ();
+        return world == null || world.isClient ? centerZ : centerZ * world.getDimension().coordinateScale();
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,8 @@
     "multiworldborders.mixins.json"
   ],
   "depends": {
+    "fabric-object-builder-api-v1": "*",
     "fabricloader": ">=0.14.6",
-    "minecraft": ">=1.20"
+    "minecraft": ">=1.20.2"
   }
 }


### PR DESCRIPTION
This continues on DrexHD's work to update to 1.20.2.

The existing version did not work for the nether. This was caused by the following phenomenon.

1. The vanilla game uses the same world border centre for all dimensions.
2. To account for different dimension sizes, the vanilla game divides the centre coordinates by the dimension's scale factor.
3. This modification unties the centres of the various worlds. This means that if we set the centre of a world, we do not need to divide it by the scale factor any more. This was already implemented.
4. An unmodified client will still divide it by the scale factor, meaning that if we set the centre to $(x; y)$ on the server, the client will convert it to $({x \\over {s}}; {y \\over {s}})$ for the dimension's scale factor $s$. This causes the centre to appear different on the client from what it actually is on the server.

To resolve this, we did not want to modify any client code. Removing the division by the scale factor on the client would make the client unable to correctly interpret world borders of unmodified servers. As such instead we modified the server to instead send the coordinates $({s \\times x}; {s \\times y})$ to every client. Vanilla clients will then divide it again by $s$ to obtain the correct coordinates $(x; y)$.

This is not the end of the story, because as said in (3), modified clients will no longer divide by the scale factor, and end up with now incorrect coordinates $({s \\times x}; {s \\times y})$.

We therefore modified the pre-existing change of (3) to only be applied on logical servers; that is, modified clients will still do the division. This keeps the behaviour of modified clients and vanilla clients identical, which allows modified clients to benefit of the modification for single player worlds, while still remaining compatible with both vanilla and modified servers.